### PR TITLE
Expose getDisplayName and set displayName only if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,22 @@ const noColor = withColor();
 const Test = noColor(Dummy);
 Test.displayName // => "Hoc(Dummy)"
 ```
+
+### Utils
+`getDisplayName :: (Component) => String`
+
+__example :__
+```js
+import React from 'react';
+import { reactHOC, getDisplayName } from 'react-hoc';
+
+const myEnhancer = reactHOC(WrappedComponent => {
+  return class extends Component {
+      // set your own displayName
+    static displayName = `Enhanced [${getDisplayName(WrappedComponent)}]`
+
+    render() { return <WrappedComponent /> }
+  };
+});
+const EnhancedDummy = myEnhancer(Dummy);
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
-const getDisplayName = WrappedComponent => (
-    WrappedComponent.displayName || WrappedComponent.name || 'Component'
-);
-
 const composeNames = (enhancerName, componentName) => (
     enhancerName ? `${enhancerName}(${componentName})` : `Hoc(${componentName})`
 );
 
-const reactHOC = (enhancer, enhancerName, customStatics) => (Component) => {
+export const getDisplayName = WrappedComponent => (
+    WrappedComponent.displayName || WrappedComponent.name || 'Component'
+);
+
+export const reactHOC = (enhancer, enhancerName, customStatics) => (Component) => {
     const enhancedDisplayName = composeNames(enhancerName, getDisplayName(Component));
     const EnhancedComponent = enhancer(Component);
     if (Component === EnhancedComponent) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,15 @@
+/* eslint-disable no-param-reassign */
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 const composeNames = (enhancerName, componentName) => (
     enhancerName ? `${enhancerName}(${componentName})` : `Hoc(${componentName})`
 );
+
+const setDisplayNameIfNot = (Component, displayName) => {
+    if (!Component.displayName)
+        Component.displayName = displayName;
+    return Component;
+};
 
 export const getDisplayName = WrappedComponent => (
     WrappedComponent.displayName || WrappedComponent.name || 'Component'
@@ -11,15 +18,12 @@ export const getDisplayName = WrappedComponent => (
 export const reactHOC = (enhancer, enhancerName, customStatics) => (Component) => {
     const enhancedDisplayName = composeNames(enhancerName, getDisplayName(Component));
     const EnhancedComponent = enhancer(Component);
-    if (Component === EnhancedComponent) {
-        EnhancedComponent.displayName = enhancedDisplayName;
-        return EnhancedComponent;
-    }
+    if (Component === EnhancedComponent)
+        return setDisplayNameIfNot(EnhancedComponent, enhancedDisplayName);
 
     const HoistedEnhanced = hoistNonReactStatics(EnhancedComponent, Component, customStatics);
     HoistedEnhanced.WrappedComponent = Component.WrappedComponent || Component;
-    HoistedEnhanced.displayName = enhancedDisplayName;
-    return HoistedEnhanced;
+    return setDisplayNameIfNot(HoistedEnhanced, enhancedDisplayName);
 };
 
 export default reactHOC;


### PR DESCRIPTION
#### in response to #4 
- export getDisplayName function
- update readme about this
in addition to 'export default', reactHOC is 'export const'

#### in response to #3 
- disable eslint no-param-reassign rule
- set displayName only if EnhancedComponent doesn't have
- add setDisplayNameIfNot() utils function (refacto)